### PR TITLE
Update DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![GitHub][github-badge]][github]
 [![Build Status]][actions]
 ![MIT License][]
-[![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.5819475-blue?style=flat-square)](https://doi.org/10.5281/zenodo.7796340)
+[![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.7796286-blue?style=flat-square)](https://doi.org/10.5281/zenodo.7796286)
 
 [github]: https://github.com/carbonplan/cdr-mrv
 [github-badge]: https://badgen.net/badge/-/github?icon=github&label


### PR DESCRIPTION
Updates the badge to link to the DOI that represents all versions so that it doesn't need to get updated each release.